### PR TITLE
Tweak migration guide PR

### DIFF
--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -124,6 +124,13 @@ you can see or infer what is being waited on: e.g. a queue, xtrigger, or
 retry timer. For instance, a waiting task that already has one or more
 associated jobs must be about to retry.
 
+Task Job Execution
+------------------
+
+User-defined job scripting is now executed in a subshell to protect job
+status messaging (which uses the Cylc Python library) from environment
+changes.
+
 Window on the Workflow
 ----------------------
 

--- a/src/7-to-8/summary.rst
+++ b/src/7-to-8/summary.rst
@@ -296,29 +296,6 @@ The following dependencies are not installed by Conda or pip:
 - GNU `coreutils`
 - `mail` (for automated email functionality)
 
-What's Still Missing From Cylc 8?
----------------------------------
-
-Some features are still in progress or yet to be started:
-
-- Other UI workflow views:
-   - graph view
-   - table view
-   - dot view
-- Static workflow graph visualization
-- Cross-user functionality and fine-grained authorization
-- UI presentation of workflow and job logs
-   - for the moment look in your ``cylc-run`` directory, or use
-     ``cylc cat-log``, or use Cylc Review from cylc-7.9.3/7.8.8 
-     to view Cylc 8 logs
-- UI/CLI "edit run"
-- UI Server:
-   - sub-service to install new workflows
-   - sub-service to start stopped workflows
-   - populate historic task data from run DBs
-
-- Delta-driven TUI, for large workflows
-
 .. _Cylc 7 Scheduler Deficiencies Fixed by Cylc 8:
 
 Cylc 7 Scheduler Deficiencies Fixed by Cylc 8


### PR DESCRIPTION
- add note on job subshells
- remove my Cylc 8 TODO list (you've replaced it with a better one)